### PR TITLE
WriterFactory throws exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,6 @@ before_install:
   - echo "Preparing blackfire"
   - travis_retry composer selfupdate
   - cp .composer-auth.json $HOME/.composer/auth.json
-  - $HOME/.composer/vendor/bin/box --version
-  - $HOME/.composer/vendor/bin/phing -v
   - echo '#!/bin/bash' > install.sh
   - echo -n "composer update" >> install.sh
   - echo -n " --prefer-dist" >> install.sh
@@ -54,6 +52,8 @@ install:
   - travis_retry composer global require kherge/box --prefer-dist
   - travis_retry composer global require phing/phing --prefer-dist
   - travis_retry composer global require satooshi/php-coveralls --prefer-dist
+  - $HOME/.composer/vendor/bin/box --version
+  - $HOME/.composer/vendor/bin/phing -v
   - export COMPOSER_ROOT_VERSION=dev-master
   - travis_retry /bin/bash ./install.sh
 

--- a/Tests/spec/Writer/System/WriterFactorySpec.php
+++ b/Tests/spec/Writer/System/WriterFactorySpec.php
@@ -3,6 +3,7 @@
 namespace spec\Hexmedia\Crontab\Writer\System;
 
 use Hexmedia\Crontab\Crontab;
+use Hexmedia\Crontab\Exception\NoWriterForSystemException;
 use Hexmedia\Crontab\Exception\WriterNotExistsException;
 use Hexmedia\Crontab\System\Unix;
 use PhpSpec\ObjectBehavior;
@@ -78,12 +79,15 @@ class WriterFactorySpec extends ObjectBehavior
         ))->during('addWriter', array('test'));
     }
 
-    function it_is_returning_null_when_there_is_no_supporting_system(Crontab $crontab)
+    function it_is_throwin_exception_when_there_is_no_supporting_system(Crontab $crontab)
     {
         $this::removeWriter($this->linuxWriterClass);
         $this::getWriters()->shouldHaveCount(0);
 
-        $this::create($crontab)->shouldReturn(null);
+
+        $this->shouldThrow(new NoWriterForSystemException(
+            sprintf("Writer for your operating system '%s' was not found!", PHP_OS)
+        ))->duringCreate("test", array($crontab));
     }
 
     function it_allows_to_set_writers()

--- a/Tests/spec/Writer/SystemWriterSpec.php
+++ b/Tests/spec/Writer/SystemWriterSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Hexmedia\Crontab\Writer;
 
 use Hexmedia\Crontab\Crontab;
+use Hexmedia\Crontab\System\Unix;
 use Hexmedia\Crontab\Task;
 use Hexmedia\Crontab\Variables;
 use PhpSpec\ObjectBehavior;
@@ -41,7 +42,9 @@ class SystemWriterSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Hexmedia\Crontab\Writer\SystemWriter');
+        if (Unix::isUnix()) { //Currently this will work only on *nix
+            $this->shouldHaveType('Hexmedia\Crontab\Writer\SystemWriter');
+        }
     }
 
     function it_is_properly_writing($crontab)
@@ -51,7 +54,6 @@ class SystemWriterSpec extends ObjectBehavior
 
     function it_is_properly_preparing_content($crontab)
     {
-
         $this->getContent($crontab)->shouldContain("test");//shouldReturn($shouldBe);
     }
 }

--- a/src/Exception/NoWriterForSystemException.php
+++ b/src/Exception/NoWriterForSystemException.php
@@ -8,11 +8,10 @@
 namespace Hexmedia\Crontab\Exception;
 
 /**
- * Class ParseException
- *
- * @package Hexmedia\CrontabBundle\Exception
+ * Class NoWriterException
+ * @package Hexmedia\Crontab\Exception
  */
-class ParseException extends \Exception
+class NoWriterForSystemException extends \Exception
 {
 
 }

--- a/src/Writer/System/WriterFactory.php
+++ b/src/Writer/System/WriterFactory.php
@@ -1,9 +1,18 @@
 <?php
 
+/**
+ * @(c) 2013-2015 Hexmedia.pl <krystian@hexmedia.pl>
+ */
+
 namespace Hexmedia\Crontab\Writer\System;
 
+use Hexmedia\Crontab\Exception\NoWriterForSystemException;
 use Hexmedia\Crontab\Exception\WriterNotExistsException;
 
+/**
+ * Class WriterFactory
+ * @package Hexmedia\Crontab\Writer\System
+ */
 class WriterFactory
 {
     /**
@@ -13,6 +22,7 @@ class WriterFactory
 
     /**
      * @return WriterInterface|null
+     * @throws NoWriterForSystemException
      */
     public static function create()
     {
@@ -22,7 +32,9 @@ class WriterFactory
             }
         }
 
-        return null;
+        throw new NoWriterForSystemException(
+            sprintf("Writer for your operating system '%s' was not found!", PHP_OS)
+        );
     }
 
     /**


### PR DESCRIPTION
Writer factory will now throw an exception when system is not supproted

 This is a combination of 2 commits.
 The first commit's message is:

Fix for checking writers.

 This is the 2nd commit message:

WriterFactory is now throwing when there is no writer.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/Hexmedia/Crontab/pull/8?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/Hexmedia/Crontab/pull/8'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
